### PR TITLE
Update RIM.py

### DIFF
--- a/RIM.py
+++ b/RIM.py
@@ -182,6 +182,7 @@ class RIMCell(nn.Module):
 	    attention_scores = torch.mean(attention_scores, dim = 1)
 	    mask_ = torch.zeros(x.size(0), self.num_units).to(self.device)
 
+            attention_scores = nn.Softmax(dim = -1)(attention_scores)
 	    not_null_scores = attention_scores[:,:, 0]
 	    topk1 = torch.topk(not_null_scores,self.k,  dim = 1)
 	    row_index = np.arange(x.size(0))
@@ -189,7 +190,7 @@ class RIMCell(nn.Module):
 
 	    mask_[row_index, topk1.indices.view(-1)] = 1
 	    
-	    attention_probs = self.input_dropout(nn.Softmax(dim = -1)(attention_scores))
+	    attention_probs = self.input_dropout(attention_scores)
 	    inputs = torch.matmul(attention_probs, value_layer) * mask_.unsqueeze(2)
 
 	    return inputs, mask_


### PR DESCRIPTION
This is based on the description given in the paper:
"Based on the softmax values in (4), we select the top k_A RIMs (out of the total K RIMs) to be activated for each step, which have the least attention on the null input,....."

Hence we have to perform softmax prior to the construction of the mask.